### PR TITLE
 Issue#8 ファイルとその中身のメモデータを渡す（color_files#show）

### DIFF
--- a/app/controllers/color_files_controller.rb
+++ b/app/controllers/color_files_controller.rb
@@ -28,7 +28,6 @@ class ColorFilesController < ApplicationController
   # GET /color_files/1
   def show
     @get_memos = Memo.joins(:tag).where(color_file_id: params[:id])
-
     @memos = @get_memos.map do | get_memo |
       {
         id: get_memo.id,
@@ -40,7 +39,14 @@ class ColorFilesController < ApplicationController
       }
     end
 
-    render json: @memos
+    @color_file = ColorFile.find(params[:id])
+    @memos_file = {
+      id: @color_file.id,
+      name: @color_file.name,
+      memos: @memos
+    }
+
+    render json: @memos_file
   end
 
   # POST /color_files

--- a/app/controllers/color_files_controller.rb
+++ b/app/controllers/color_files_controller.rb
@@ -1,5 +1,5 @@
 class ColorFilesController < ApplicationController
-  before_action :set_color_file, only: %i[ show update destroy ]
+  before_action :set_color_file, only: %i[ update destroy ]
 
   # GET /color_files
   def index
@@ -27,7 +27,20 @@ class ColorFilesController < ApplicationController
 
   # GET /color_files/1
   def show
-    render json: @color_file
+    @get_memos = Memo.joins(:tag).where(color_file_id: params[:id])
+
+    @memos = @get_memos.map do | get_memo |
+      {
+        id: get_memo.id,
+        color_code: get_memo.color_code,
+        comment: get_memo.comment,
+        URL: get_memo.url,
+        tag_name: get_memo.tag.name,
+        created_at: get_memo.created_at
+      }
+    end
+
+    render json: @memos
   end
 
   # POST /color_files

--- a/app/controllers/memos_controller.rb
+++ b/app/controllers/memos_controller.rb
@@ -26,24 +26,6 @@ class MemosController < ApplicationController
     render json: @memo
   end
 
-  # GET /file/1
-  def show_inFile
-    @get_memos = Memo.joins(:tag).where(color_file_id: params[:id])
-
-    @memos = @get_memos.map do | get_memo |
-      {
-        id: get_memo.id,
-        color_code: get_memo.color_code,
-        comment: get_memo.comment,
-        URL: get_memo.url,
-        tag_name: get_memo.tag.name,
-        created_at: get_memo.created_at
-      }
-    end
-
-    render json: @memos
-  end
-
   # GET /memos/search
   def search
     @get_memos = Memo.joins(:tag).where('tags.name = ?', params[:q])

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,9 +4,6 @@ Rails.application.routes.draw do
   resources :color_files
   resources :users
 
-  # ファイルを指定してその中にあるメモを返す
-  get 'files/:id', to: 'memos#show_inFile'
-
   # タグ検索
   get 'search', to: 'memos#search'
 end

--- a/test.http
+++ b/test.http
@@ -1,4 +1,4 @@
-GET http://127.0.0.1:3000/files/1 HTTP/1.1
+GET http://127.0.0.1:3000/color_files/1 HTTP/1.1
 content-type: application/json
 
 {


### PR DESCRIPTION
## やったこと
- memosコントローラー内に書いていた`#show_inFile`を削除し、`color_files#show`に移行
- 返すデータにファイルIDとファイル名データを追加
↓実際に`color_files/:id`を叩いて返したデータ
<img width="481" alt="data" src="https://user-images.githubusercontent.com/93811872/180488916-8f71e325-5f50-46c3-9a55-ba2b2b56ba55.png">
