### PR TITLE
Issue#13 ファイルの削除（color_files#destroy） 

### DIFF
--- a/app/controllers/color_files_controller.rb
+++ b/app/controllers/color_files_controller.rb
@@ -59,8 +59,6 @@ class ColorFilesController < ApplicationController
     # Use callbacks to share common setup or constraints between actions.
     def set_color_file
       @color_file = ColorFile.find(params[:id])
-
-      render json: @color_file
     end
 
     # Only allow a list of trusted parameters through.

--- a/app/models/color_file.rb
+++ b/app/models/color_file.rb
@@ -1,6 +1,6 @@
 class ColorFile < ApplicationRecord
   belongs_to :user
-  has_many :memos
+  has_many :memos, dependent: :destroy
 
   validates :name, uniqueness: { scope: :user_id  }
 end

--- a/test.http
+++ b/test.http
@@ -1,4 +1,4 @@
-GET http://127.0.0.1:3000/files/1 HTTP/1.1
+GET http://127.0.0.1:3000/color_files HTTP/1.1
 content-type: application/json
 
 {


### PR DESCRIPTION
## やったこと
- DELETE color_files/:id を叩いてもデータが削除されず、指定したidのデータを参照するだけだったのでその挙動の原因探し（[updateできない問題](https://github.com/pppeyo38/16memo_backend/pull/14#discussion_r928071443)と解決策が一緒だった）
- ファイルを削除したとき、そのファイル内に入ってるメモも削除されるよう関連付けの追記